### PR TITLE
Support later version .full api

### DIFF
--- a/spirl/models/closed_loop_spirl_mdl.py
+++ b/spirl/models/closed_loop_spirl_mdl.py
@@ -19,7 +19,7 @@ class ClSPiRLMdl(SkillPriorMdl):
                                  output_size=self._hp.action_dim,
                                  mid_size=self._hp.nz_mid_prior)
         self.p = self._build_prior_ensemble()
-        self.log_sigma = get_constant_parameter(0, learnable=False)
+        self.log_sigma = get_constant_parameter(0., learnable=False)
 
     def decode(self, z, cond_inputs, steps, inputs=None):
         assert inputs is not None       # need additional state sequence input for full decode


### PR DESCRIPTION
Later version of PyTorch(tested on 1.6.0) raises error if data type is not given for .full(shape, 0) :
```
/v4/namsan/ORLMRL/lib/spirl/spirl/utils/pytorch_utils.py in get_constant_parameter(init_log_value, learnable)
    524 
    525 def get_constant_parameter(init_log_value, learnable):
--> 526     return torch.nn.Parameter(torch.full((1,), init_log_value)[0], requires_grad=learnable)
    527 
    528 

RuntimeError: Providing a bool or integral fill value without setting the optional `dtype` or `out` arguments is currently unsupported. In PyTorch 1.7, when `dtype` and `out` are not set a bool fill value will return a tensor of torch.bool dtype, and an integral fill value will return a tensor of torch.long dtype.
```
This pull request fixes this behavior by giving the initial log sigma value (0) as float (0.) in ClSPiRLMdl.